### PR TITLE
fix: Add possibility for additional parameters to acme.sh

### DIFF
--- a/ubios-cert/ubios-cert.env
+++ b/ubios-cert/ubios-cert.env
@@ -50,6 +50,16 @@ UBIOS_CERT_ROOT='/mnt/data/ubios-cert'
 # This is where the deploy script has extracted acme.sh
 ACMESH_ROOT="${UBIOS_CERT_ROOT}"/acme.sh
 
+# The following can be used to provide additional parameters for acme.sh, e.g. a
+# static dnssleep (https://github.com/acmesh-official/acme.sh/wiki/dnssleep)
+# instead of a dynamic checking via google or cloudflare dns.
+# ACMESH_CMD_PARAMS="--dnssleep 600"
+# Can also be used to perform notifications via various channels as described
+# here: https://github.com/acmesh-official/acme.sh/wiki/notify e.g. for GChat:
+# export SAVED_GCHAT_WEBHOOK_URL='paste your webbook url here'
+# ACMESH_CMD_PARAMS="--set-notify --notify-hook gchat"
+ACMESH_CMD_PARAMS=""
+
 # These should only change if Unifi-OS core changes require it
 # Confirmed to work with Firmwares:
 # 1.8.6 on February 14, 2021

--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -119,7 +119,7 @@ done
 ACME_CERT_NAME=$(echo "${CERT_NAME}" | sed -r 's/\*/_/g')
 
 ACME_HOME="--config-home ${UBIOS_CERT_ROOT}/acme.sh --cert-home ${UBIOS_CERT_ROOT}/acme.sh --home ${UBIOS_CERT_ROOT}/acme.sh"
-ACME_CMD="${UBIOS_CERT_ROOT}/acme.sh/acme.sh ${ACME_HOME}"
+ACME_CMD="${UBIOS_CERT_ROOT}/acme.sh/acme.sh ${ACMESH_CMD_PARAMS} ${ACME_HOME}"
 
 
 # Setup persistent on_boot.d trigger


### PR DESCRIPTION
This adds the possibility to add parameters for acme.sh into the environment configuration.

In my case my dns provider required a dnssleep since the lookup via google dns wasn't reliable enough. Additionally i wanted to know via notification of new renewals.