### PR TITLE
Fix #26: Check for the presence of /etc/init.d/crond or /etc/init.d/cron instead of relying on $IS_UNIFI_2

### DIFF
--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -136,10 +136,13 @@ CRON_FILE='/etc/cron.d/ubios-cert'
 if [ ! -f "${CRON_FILE}" ]; then
 	echo "0 3 * * * sh ${UBIOS_CERT_ROOT}/ubios-cert.sh renew" >${CRON_FILE}
 	chmod 644 ${CRON_FILE}
-	if [ ${IS_UNIFI_2} = 'false' ]; then 
-		/etc/init.d/cron reload ${CRON_FILE}
-	else 
+	if [ -f /etc/init.d/crond ]; then
 		/etc/init.d/crond reload ${CRON_FILE}
+	elif [ -f /etc/init.d/cron ]; then
+		/etc/init.d/cron reload ${CRON_FILE}
+	else
+		echo "ERROR: Could not find cron service at /etc/init.d/crond or /etc/init.d/cron" >&2
+		exit 1
 	fi
 	echo "Restored cron file"
 fi


### PR DESCRIPTION
This fixes the crash I experienced when running the script on my UDM. Instead of checking the output of `ubnt-device-info model`, just check for `/etc/init.d/crond` or `/etc/init.d/cron`

```
# ubnt-device-info model
UniFi Dream Machine

# ubnt-device-info summary
Device information summary:
        Subsystem ID: ea11
              Family: UniFi Dream Machine (UDM)
               Model: UniFi Dream Machine (UDM)
 Default MAC address: **:**:**:**:**:**
Default IPv4 address: 127.0.0.1
            Firmware: 1.12.30 (1.12.30)
```

