### PR TITLE
update logic to set DATA_DIR based on firmware version

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,10 @@ SCRIPT_DIR=$(dirname ${0})
 
 # Set default data path
 export DATA_DIR="/mnt/data"
+# Get the firmware version
+export FIRMWARE_VER=$(ubnt-device-info firmware || true)
+# Get the Harware Model
+export MODEL=$(ubnt-device-info model || true)
 
 deploy_acmesh() {
 	echo "acme.sh will be deployed inside ubios-cert to persist firmware updates"
@@ -15,16 +19,15 @@ deploy_acmesh() {
 	tar -xvf acmesh.tar.gz --directory="${SCRIPT_DIR}/ubios-cert/acme.sh" --strip-components=1 
 }
 
-if [ $(ubnt-device-info firmware || true) > 2 ]
+if [ ${FIRMWARE_VER} > 2 ]
  then
         sed -i 's#/mnt/data#/data#g' "${SCRIPT_DIR}/ubios-cert/ubios-cert.env" "${SCRIPT_DIR}/ubios-cert/ubios-cert.sh" "${SCRIPT_DIR}/ubios-cert/on_boot.d/99-ubios-cert.sh"
         export DATA_DIR="/data"
 fi
 
-MODEL=$(ubnt-device-info model || true)
 case "${MODEL}" in
 	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE")
-	echo "${MODEL} detected, installing ubios-cert in ${DATA_DIR}..."
+	echo "${MODEL} running firmware ${FIRMWARE_VER} detected, installing ubios-cert in ${DATA_DIR}..."
 	;;
 	*)
 	echo "Unsupported model: $(ubnt-device-info model)" 1>&2

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,9 @@
 set -e
 SCRIPT_DIR=$(dirname ${0})
 
+# Set default data path
+export DATA_DIR="/mnt/data"
+
 deploy_acmesh() {
 	echo "acme.sh will be deployed inside ubios-cert to persist firmware updates"
 	ACME_URL=$(curl -s https://api.github.com/repos/acmesh-official/acme.sh/releases/latest | grep tarball_url | awk '{ print $2 }' | sed 's/,$//' | sed 's/"//g')
@@ -12,15 +15,16 @@ deploy_acmesh() {
 	tar -xvf acmesh.tar.gz --directory="${SCRIPT_DIR}/ubios-cert/acme.sh" --strip-components=1 
 }
 
-case "$(ubnt-device-info model || true)" in
-	"UniFi Dream Machine Pro"|"UniFi Dream Machine")
-	echo "UDM/UDM Pro detected, installing ubios-cert in /mnt/data..."
-	export DATA_DIR="/mnt/data"
-	;;
-	"UniFi Dream Router"|"UniFi Dream Machine SE")
-	echo "UDR/UDM SE detected, installing ubios-cert in /data..."
-	sed -i 's#/mnt/data#/data#g' "${SCRIPT_DIR}/ubios-cert/ubios-cert.env" "${SCRIPT_DIR}/ubios-cert/ubios-cert.sh" "${SCRIPT_DIR}/ubios-cert/on_boot.d/99-ubios-cert.sh"
-	export DATA_DIR="/data"
+if [ $(ubnt-device-info firmware || true) > 2 ]
+ then
+        sed -i 's#/mnt/data#/data#g' "${SCRIPT_DIR}/ubios-cert/ubios-cert.env" "${SCRIPT_DIR}/ubios-cert/ubios-cert.sh" "${SCRIPT_DIR}/ubios-cert/on_boot.d/99-ubios-cert.sh"
+        export DATA_DIR="/data"
+fi
+
+MODEL=$(ubnt-device-info model || true)
+case "${MODEL}" in
+	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE")
+	echo "${MODEL} detected, installing ubios-cert in ${DATA_DIR}..."
 	;;
 	*)
 	echo "Unsupported model: $(ubnt-device-info model)" 1>&2


### PR DESCRIPTION
With the UDM and UDM-PRO getting 2.x firmware in early access there is a need to support different locations based on firmware version and not model, fixes #29 

Signed-off-by: Dennis Gilmore <dennis@ausil.us>