### PR TITLE
Quote string for $MODEL value and use $MODEL for error case

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,7 +7,7 @@ export DATA_DIR="/mnt/data"
 # Get the firmware version
 export FIRMWARE_VER=$(ubnt-device-info firmware || true)
 # Get the Harware Model
-export MODEL=$(ubnt-device-info model || true)
+export MODEL="$(ubnt-device-info model || true)"
 
 deploy_acmesh() {
 	echo "acme.sh will be deployed inside ubios-cert to persist firmware updates"
@@ -30,7 +30,7 @@ case "${MODEL}" in
 	echo "${MODEL} running firmware ${FIRMWARE_VER} detected, installing ubios-cert in ${DATA_DIR}..."
 	;;
 	*)
-	echo "Unsupported model: $(ubnt-device-info model)" 1>&2
+	echo "Unsupported model: ${MODEL}"
 	exit 1
 	;;
 esac

--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -17,6 +17,10 @@ LOG="${LOGFILE} ${LOGLEVEL}"
 
 NEW_CERT='no'
 IS_UNIFI_2='false'
+if [ $(ubnt-device-info firmware || true) > 2 ]
+ then
+	 IS_UNIFI_2='true'
+fi
 
 deploy_cert() {
 	if [ "$(find -L "${ACMESH_ROOT}" -type f -name fullchain.cer -mmin -5)" ]; then
@@ -86,13 +90,6 @@ remove_cert() {
 	${ACME_CMD} --remove ${DOMAINS}
 	echo "Removed certificates from acme.sh renewal. The certificate files can now manually be removed."
 }
-
-# When running in UDM SE / UDR, the applications are not running in containers
-case "$(ubnt-device-info model || true)" in "UniFi Dream Machine SE"|"UniFi Dream Router")
-	# But here, the same command will be executed but inside unifi-os container
-	IS_UNIFI_2='true'
-	;;
-esac
 
 # Check for and if not exists create acme.sh directory so the container can write to it - owner "nobody"
 if [ ! -d "${ACMESH_ROOT}" ]; then


### PR DESCRIPTION
Make sure that all of $MODEL is always there by quoting where there variable is defined. since we have the value in a variable use it in the error case also

Signed-off-by: Dennis Gilmore <dennis@ausil.us>