### PR TITLE
Fix the if statements to do a proper version comparison

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -19,7 +19,7 @@ deploy_acmesh() {
 	tar -xvf acmesh.tar.gz --directory="${SCRIPT_DIR}/ubios-cert/acme.sh" --strip-components=1 
 }
 
-if [ ${FIRMWARE_VER} > 2 ]
+if [ $(echo ${FIRMWARE_VER} | sed 's#\..*$##g') -gt 1 ]
  then
         sed -i 's#/mnt/data#/data#g' "${SCRIPT_DIR}/ubios-cert/ubios-cert.env" "${SCRIPT_DIR}/ubios-cert/ubios-cert.sh" "${SCRIPT_DIR}/ubios-cert/on_boot.d/99-ubios-cert.sh"
         export DATA_DIR="/data"

--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -17,7 +17,7 @@ LOG="${LOGFILE} ${LOGLEVEL}"
 
 NEW_CERT='no'
 IS_UNIFI_2='false'
-if [ $(ubnt-device-info firmware || true) > 2 ]
+if [ $(ubnt-device-info firmware | sed 's#\..*$##g' || true) -gt 1 ]
  then
 	 IS_UNIFI_2='true'
 fi


### PR DESCRIPTION
shell script uses -gt not > for greater than. as the firmware version is not an integer and the comparison has to be on intergets strip the trailing values as we are just checking for the major version

Signed-off-by: Dennis Gilmore <dennis@ausil.us>