### PR TITLE
Fix for evostreams being unable to access unifi-core.key, which breaks RTSPS feeds from protect.

### DIFF
--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -34,7 +34,7 @@ deploy_cert() {
 		cp -f ${ACMESH_ROOT}/${CERT_NAME}/${CERT_NAME}.key ${UNIFIOS_CERT_PATH}/unifi-core.key
 		cp -f ${ACMESH_ROOT}/${CERT_NAME}/${CERT_NAME}.key ${UNIFIOS_CERT_PATH}/unifi-core-direct.key
 		chmod 644 ${UNIFIOS_CERT_PATH}/unifi-core.crt ${UNIFIOS_CERT_PATH}/unifi-core-direct.crt
-		chmod 600 ${UNIFIOS_CERT_PATH}/unifi-core.key ${UNIFIOS_CERT_PATH}/unifi-core-direct.key
+		chmod 644 ${UNIFIOS_CERT_PATH}/unifi-core.key ${UNIFIOS_CERT_PATH}/unifi-core-direct.key
 		NEW_CERT='yes'
 	else
 		echo 'No new certificate was found, exiting without restart'


### PR DESCRIPTION
After using this I noticed that my rtsps feeds from protect (in use with home assistant) no longer functioned -- because these are served by the evostreams process which runs under the unifi-protect user the 600 permissions are not enough to allow access and those streams will never work, 644 is the minimum for functionality.
