### PR TITLE
Don't copy the `-direct` crt and key to UNIFIOS_CERT_PATH

### DIFF
--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -33,11 +33,7 @@ deploy_cert() {
 		echo 'New certificate was generated, time to deploy it'
 		# Controller certificate - copy the full chain certificates to unifi-core.crt to avoid Java cert store command error
 		cp -f ${ACMESH_ROOT}/${CERT_NAME}/fullchain.cer ${UNIFIOS_CERT_PATH}/unifi-core.crt
-		cp -f ${ACMESH_ROOT}/${CERT_NAME}/fullchain.cer ${UNIFIOS_CERT_PATH}/unifi-core-direct.crt
 		cp -f ${ACMESH_ROOT}/${CERT_NAME}/${CERT_NAME}.key ${UNIFIOS_CERT_PATH}/unifi-core.key
-		cp -f ${ACMESH_ROOT}/${CERT_NAME}/${CERT_NAME}.key ${UNIFIOS_CERT_PATH}/unifi-core-direct.key
-		chmod 644 ${UNIFIOS_CERT_PATH}/unifi-core.crt ${UNIFIOS_CERT_PATH}/unifi-core-direct.crt
-		chmod 644 ${UNIFIOS_CERT_PATH}/unifi-core.key ${UNIFIOS_CERT_PATH}/unifi-core-direct.key
 		NEW_CERT='yes'
 	else
 		echo 'No new certificate was found, exiting without restart'


### PR DESCRIPTION
# Description

This fixes issue #56.

The `unifi-core-direct` .crt and .key was causing issues with `UniFi OS UDM Pro: v3.0.20`. All DNS queries to `*.mydomain.com` were being resolved to the gateway.

## Fix

Don't copy over `unifi-core-direct.crt` and `unifi-core-direct.key`.
