### PR TITLE
Add UniFi Express and Dream Wall and fix webportal deployment issue

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ if [ $(echo ${FIRMWARE_VER} | sed 's#\..1$##g') = "4.1" ]
 fi
 
 case "${MODEL}" in
-	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE"|"UniFi Express")
+	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE"|"UniFi Express"|"UniFi Dream Wall")
 	echo "${MODEL} running firmware ${FIRMWARE_VER} detected, installing ubios-cert in ${DATA_DIR}..."
 	;;
 	*)

--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ if [ $(echo ${FIRMWARE_VER} | sed 's#\..1$##g') = "4.1" ]
 fi
 
 case "${MODEL}" in
-	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE")
+	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE"|"UniFi Express")
 	echo "${MODEL} running firmware ${FIRMWARE_VER} detected, installing ubios-cert in ${DATA_DIR}..."
 	;;
 	*)

--- a/ubios-cert/ubios-cert.sh
+++ b/ubios-cert/ubios-cert.sh
@@ -63,6 +63,7 @@ deploy_webfrontend() {
 	if [ "$(find -L "${ACMESH_ROOT}" -type f -name fullchain.cer -mmin -5)" ]; then
 		# beginning with 3.2.7, no need to copy the cert and key, but point in the right direction via a YAML file
 		if [[ ! -f "${UNIFI_CORE_SSL_CONFIG}" ]]; then
+  			mkdir -p "$(dirname "${UNIFI_CORE_SSL_CONFIG}")"
 			tee "${UNIFI_CORE_SSL_CONFIG}" &>/dev/null << SSL
 # File created by ubios-cert (certificates for Unifi Dream Machines).
 ssl:


### PR DESCRIPTION
Added two more machines in the deploy.sh
- UniFi Express
- UniFi Dream Wall

Fixed a bug in the deploy_webfrontend
- When the cert yaml file does not exist, it should try to create the folder tree before trying to create the file.