### PR TITLE
Add UDM Pro Max

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ if [ $(echo ${FIRMWARE_VER} | sed 's#\..1$##g') = "4.1" ]
 fi
 
 case "${MODEL}" in
-	"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE"|"UniFi Express"|"UniFi Dream Wall")
+	"UniFi Dream Machine Pro Max"|"UniFi Dream Machine Pro"|"UniFi Dream Machine"|"UniFi Dream Router"|"UniFi Dream Machine SE"|"UniFi Express"|"UniFi Dream Wall")
 	echo "${MODEL} running firmware ${FIRMWARE_VER} detected, installing ubios-cert in ${DATA_DIR}..."
 	;;
 	*)


### PR DESCRIPTION
Add UDM Pro Max in the supported models for `deploy.sh`. Verified working on my own UDM Pro Max with version 4.1.13 of the firmware.